### PR TITLE
Add address to info box

### DIFF
--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -83,7 +83,6 @@ async function getAddress(lat, long) {
 
 map.on('click', 'points', function (event) {
   if (!addModeEnabled) {
-    console.log(event)
     type = event.features[0].properties.binTypeName
     getAddress(event.lngLat.lng, event.lngLat.lat).then((address) => {
       new mapboxgl.Popup()

--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -61,14 +61,39 @@ map.on("load", async function() {
 
 map.addControl(geoLocation);
 
+var mapboxClient = mapboxSdk({ accessToken: mapboxgl.accessToken });
+
+async function getAddress(lat, long) {
+  let address
+  await mapboxClient.geocoding.reverseGeocode({
+    query: [lat, long],
+    limit: 1
+  })
+    .send()
+    .then(response => {
+      if (response.body.features.length > 0) {
+        address = (response.body.features[0].place_name)
+      } else {
+        address = "No address found"
+      }
+    })
+  return address
+}
+
+
 map.on('click', 'points', function (event) {
   if (!addModeEnabled) {
-    new mapboxgl.Popup()
-    .setLngLat(event.lngLat)
-    .setHTML("<h3>" + event.features[0].properties.binTypeName + "</h3>" + "<p>" + event.lngLat + "</p>")
-    .addTo(map);
+    console.log(event)
+    type = event.features[0].properties.binTypeName
+    getAddress(event.lngLat.lng, event.lngLat.lat).then((address) => {
+      new mapboxgl.Popup()
+      .setLngLat(event.lngLat)  
+      .setHTML("<h3>" + type + "</h3>" + "<h4> Address </h4>" + "<p>" + address + "</p>")
+      .addTo(map);
+    })
   }
 });
+
 
 // Change the cursor to a pointer when the mouse is over the states layer.
 map.on('mouseenter', 'states-layer', function () {

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="/custom.css">
     <script src='https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
     <link href='https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet'/>
+    <script src="https://unpkg.com/@mapbox/mapbox-sdk/umd/mapbox-sdk.min.js"></script>
     <script>
         mapboxgl.accessToken = '{{mapboxKey}}';
     </script>


### PR DESCRIPTION
Using mapbox-sdk-js - https://github.com/mapbox/mapbox-sdk-js

In order to get an address from the coordinates, we query the reverse geocoding endpoint on the Mapbox API - info here: https://github.com/mapbox/mapbox-sdk-js/blob/master/docs/services.md#reversegeocode

When a user clicks on a bin marker, the API is queried before the info box is populated with the bin type and address

We'll need to merge this carefully with Anthony's navigation changes.