### PR TITLE
Delete bins

### DIFF
--- a/models/bin.js
+++ b/models/bin.js
@@ -8,7 +8,9 @@ const binSchema = new mongoose.Schema({
     required: true,
     default: "Feature"
   },
-  properties: { type: mongoose.Schema.Types.ObjectId, ref: "BinType" },
+  properties: { 
+    binType: { type: mongoose.Schema.Types.ObjectId, ref: "BinType" }
+  },
   geometry: {
     type: {
       type: String,
@@ -22,6 +24,13 @@ const binSchema = new mongoose.Schema({
     }
   }
 });
+
+binSchema.virtual('properties.binId').get(function() {
+  return this._id.toHexString();
+})
+
+binSchema.set('toJSON', {virtuals: true})
+binSchema.set('toObject', {virtuals: true})
 
 
 module.exports = mongoose.model("Bin", binSchema);

--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -52,7 +52,7 @@ map.on("load", async function() {
       "type": "symbol",
       "source": "allBins",
       "layout": {
-        "icon-image": ['get','iconUrl', ['get', 'icon']],
+        "icon-image": ['get', 'iconUrl', ['get', 'icon', ['get', 'binType']]],
         "icon-size": 0.3
       }
     });
@@ -82,25 +82,27 @@ async function getAddress(lat, long) {
 
 
 map.on('click', 'points', function(event) {
-  console.log(event)
+  // console.log(event)
   const clickedPoint = event.features[0]
   console.log(clickedPoint)
+  // console.log(clickedPoint.geometry.coordinates)
+  console.log(event.lngLat)
+  const binLng = clickedPoint.geometry.coordinates[0]
+  const binLat = clickedPoint.geometry.coordinates[1]
+  const binType = JSON.parse(clickedPoint.properties.binType).binTypeName
+  const binId = clickedPoint.properties.binId
   if (!addModeEnabled) {
-    new mapboxgl.Popup()
-      .setLngLat(event.lngLat)
-      .addTo(map);
-
-    getAddress(event.lngLat.lng, event.lngLat.lat).then((address) => {
+    getAddress(binLng, binLat).then((address) => {
       new mapboxgl.Popup()
-        .setLngLat(event.lngLat)
+        .setLngLat({lng: binLng, lat: binLat})
         .setHTML(
           `
-          <h3> ${clickedPoint.properties.binTypeName} </h3>
+          <h3> ${binType} </h3>
           <h5>Address:</h4> 
           <p>${address}</p>
           <br>
           <button type="button" class="btn btn-primary" id="directions" onclick="startDirections(${event.lngLat.lng.toFixed(5)},${event.lngLat.lat.toFixed(5)})">Directions</button>
-          <button type="button" class="btn btn-danger" id="delete" onclick="deleteBin(${event.lngLat.lng},${event.lngLat.lat})">Delete</button>\
+          <button type="button" class="btn btn-danger" id="delete" onclick="deleteBin(${binLng},${binLat})">Delete</button>\
           `,
         )
         .addTo(map);
@@ -116,8 +118,7 @@ function deleteBin(binLng, binLat) {
     contentType: 'application/json',
     data: JSON.stringify({
       bin: {
-        lng: binLng,
-        lat: binLat
+        id: binId,
       }
     })
   })

--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -84,16 +84,11 @@ async function getAddress(lat, long) {
 }
 
 map.on('click', 'points', function(event) {
-  // console.log(event)
   const clickedPoint = event.features[0]
-  console.log(clickedPoint)
-  // console.log(clickedPoint.geometry.coordinates)
-  console.log(event.lngLat)
   const binLng = clickedPoint.geometry.coordinates[0]
   const binLat = clickedPoint.geometry.coordinates[1]
   const binType = JSON.parse(clickedPoint.properties.binType).binTypeName
   const binId = clickedPoint.properties.binId
-  console.log(binId)
   if (!addModeEnabled) {
     getAddress(binLng, binLat).then((address) => {
       theBox = new mapboxgl.Popup()
@@ -150,7 +145,6 @@ function deleteBin(deleteId) {
 
 
 function startDirections(lng,lat) {
-  console.log(lng,lat)
   directions = new MapboxDirections(({
     accessToken: mapboxgl.accessToken,
     interactive: false,

--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -1,4 +1,5 @@
 let directions
+let theBox
 
 var map = new mapboxgl.Map({
   container: "map",
@@ -95,7 +96,7 @@ map.on('click', 'points', function(event) {
   console.log(binId)
   if (!addModeEnabled) {
     getAddress(binLng, binLat).then((address) => {
-      new mapboxgl.Popup()
+      theBox = new mapboxgl.Popup()
         .setLngLat({lng: binLng, lat: binLat})
         .setHTML(
           `
@@ -114,18 +115,37 @@ map.on('click', 'points', function(event) {
 
 function deleteBin(deleteId) {
   $.ajax({
-    type: "DELETE",
-    url: `/api/bins`,
-    contentType: 'application/json',
-    data: JSON.stringify({
-      bin: {
-        id: deleteId,
-      }
-    })
-  })
-  .done(function(result){
-    refreshMapData()
-  })
+    url: '/api/users/current',
+    type: 'get',
+    headers: {
+      Authorization: 'Token ' + $.cookie('Auth')
+    },
+    success: function(response, error) {
+      $.ajax({
+        type: "DELETE",
+        url: `/api/bins`,
+        headers: {
+          Authorization: 'Token ' + $.cookie('Auth')
+        },
+        contentType: 'application/json',
+        data: JSON.stringify({
+          bin: {
+            id: deleteId,
+          }
+        })
+      })
+      .done(function(result){
+        refreshMapData()
+        theBox.remove()
+      })
+    },
+    error: function() {
+      window.location.replace('/login');
+    }
+  });
+
+
+  
 }
 
 

--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -91,6 +91,7 @@ map.on('click', 'points', function(event) {
   const binLat = clickedPoint.geometry.coordinates[1]
   const binType = JSON.parse(clickedPoint.properties.binType).binTypeName
   const binId = clickedPoint.properties.binId
+  console.log(binId)
   if (!addModeEnabled) {
     getAddress(binLng, binLat).then((address) => {
       new mapboxgl.Popup()
@@ -102,7 +103,7 @@ map.on('click', 'points', function(event) {
           <p>${address}</p>
           <br>
           <button type="button" class="btn btn-primary" id="directions" onclick="startDirections(${event.lngLat.lng.toFixed(5)},${event.lngLat.lat.toFixed(5)})">Directions</button>
-          <button type="button" class="btn btn-danger" id="delete" onclick="deleteBin(${binLng},${binLat})">Delete</button>\
+          <button type="button" class="btn btn-danger" id="delete" onclick="deleteBin('${binId}')">Delete</button>
           `,
         )
         .addTo(map);
@@ -110,15 +111,14 @@ map.on('click', 'points', function(event) {
   }
 });
 
-function deleteBin(binLng, binLat) {
-  console.log(binLng + ' - ' + binLat)
+function deleteBin(deleteId) {
   $.ajax({
     type: "DELETE",
     url: `/api/bins`,
     contentType: 'application/json',
     data: JSON.stringify({
       bin: {
-        id: binId,
+        id: deleteId,
       }
     })
   })

--- a/public/map/mapbox.js
+++ b/public/map/mapbox.js
@@ -82,27 +82,49 @@ async function getAddress(lat, long) {
 
 
 map.on('click', 'points', function(event) {
+  console.log(event)
+  const clickedPoint = event.features[0]
+  console.log(clickedPoint)
   if (!addModeEnabled) {
     new mapboxgl.Popup()
       .setLngLat(event.lngLat)
-
       .addTo(map);
-    type = event.features[0].properties.binTypeName;
+
     getAddress(event.lngLat.lng, event.lngLat.lat).then((address) => {
       new mapboxgl.Popup()
         .setLngLat(event.lngLat)
         .setHTML(
           `
-          <h3> ${type} </h3>
-          <p>Longitude: ${event.lngLat.lng.toFixed(5)} <br> Latitude: ${event.lngLat.lat.toFixed(5)} </p>
+          <h3> ${clickedPoint.properties.binTypeName} </h3>
+          <h5>Address:</h4> 
+          <p>${address}</p>
           <br>
           <button type="button" class="btn btn-primary" id="directions" onclick="startDirections(${event.lngLat.lng.toFixed(5)},${event.lngLat.lat.toFixed(5)})">Directions</button>
-           `,
+          <button type="button" class="btn btn-danger" id="delete" onclick="deleteBin(${event.lngLat.lng},${event.lngLat.lat})">Delete</button>\
+          `,
         )
         .addTo(map);
     });
   }
 });
+
+function deleteBin(binLng, binLat) {
+  console.log(binLng + ' - ' + binLat)
+  $.ajax({
+    type: "DELETE",
+    url: `/api/bins`,
+    contentType: 'application/json',
+    data: JSON.stringify({
+      bin: {
+        lng: binLng,
+        lat: binLat
+      }
+    })
+  })
+  .done(function(result){
+    refreshMapData()
+  })
+}
 
 
 function startDirections(lng,lat) {

--- a/routes/api/bins.js
+++ b/routes/api/bins.js
@@ -48,17 +48,7 @@ router.post("/", (request, response) => {
 });
 
 router.delete("/", (request, response) => {
-
   binId = request.body.bin.id
-  console.log('BIN ID IN DELETE')
-  console.log(request.body)
-  // console.log(binId)
-  Bin.findById(binId, (err, result) => {
-    console.log('FOUND BIN')
-
-    console.log(result)
-  })
-
 
   Bin.deleteMany({
     _id: binId

--- a/routes/api/bins.js
+++ b/routes/api/bins.js
@@ -3,10 +3,10 @@ const mongoose = require("mongoose");
 const Bin = mongoose.model("Bin");
 const BinType = mongoose.model("BinType");
 
-
+// { geometry: 1, type: 1, _id: 0, properties: 1 }
 router.get("/", (request, response) => {
-  Bin.find({}, { geometry: 1, type: 1, _id: 0, properties: 1 })
-    .populate("properties")
+  Bin.find({}, { geometry: 1, type: 1, properties: 1})
+    .populate('properties.binType')
     .exec(function(err, bins) {
       // if (err) return err
       const binsCollection = {
@@ -52,10 +52,14 @@ router.delete("/", (request, response) => {
   lat = request.body.bin.lat
   console.log([lng, lat])
 
-  Bin.findOne({}, (err, result) => {
-    console.log(result)
-  })
-  
+  // Bin.findOne({geometry: {
+  //   type: 'Point',
+  //   coordinates: [-0.09634240078182188 - 51.52529864865096]
+  // }}, (err, result) => {
+  //   console.log(result)
+  // })
+
+
   Bin.deleteMany({
     geometry: {
       type: 'Point',

--- a/routes/api/bins.js
+++ b/routes/api/bins.js
@@ -48,25 +48,24 @@ router.post("/", (request, response) => {
 });
 
 router.delete("/", (request, response) => {
-  lng = request.body.bin.lng
-  lat = request.body.bin.lat
-  console.log([lng, lat])
 
-  // Bin.findOne({geometry: {
-  //   type: 'Point',
-  //   coordinates: [-0.09634240078182188 - 51.52529864865096]
-  // }}, (err, result) => {
-  //   console.log(result)
-  // })
+  binId = request.body.bin.id
+  console.log('BIN ID IN DELETE')
+  console.log(request.body)
+  // console.log(binId)
+  Bin.findById(binId, (err, result) => {
+    console.log('FOUND BIN')
+
+    console.log(result)
+  })
 
 
   Bin.deleteMany({
-    geometry: {
-      type: 'Point',
-      coordinates: [lng, lat]
-    }
+    _id: binId
   }, (err, numberRemoved) => {
-    if (numberRemoved.deletedCount === 0) {
+    if(!numberRemoved) {
+      response.status(400).json({ status: "Invalid request" } ).send()
+    } else if (numberRemoved.deletedCount === 0) {
       response.status(409).json({ status: "No bins deleted" } ).send()
     } else {
       response.json({ status: "success" } ).send()

--- a/routes/api/bins.js
+++ b/routes/api/bins.js
@@ -3,6 +3,7 @@ const mongoose = require("mongoose");
 const Bin = mongoose.model("Bin");
 const BinType = mongoose.model("BinType");
 
+
 router.get("/", (request, response) => {
   Bin.find({}, { geometry: 1, type: 1, _id: 0, properties: 1 })
     .populate("properties")
@@ -45,5 +46,28 @@ router.post("/", (request, response) => {
     };
   });
 });
+
+router.delete("/", (request, response) => {
+  lng = request.body.bin.lng
+  lat = request.body.bin.lat
+  console.log([lng, lat])
+
+  Bin.findOne({}, (err, result) => {
+    console.log(result)
+  })
+  
+  Bin.deleteMany({
+    geometry: {
+      type: 'Point',
+      coordinates: [lng, lat]
+    }
+  }, (err, numberRemoved) => {
+    if (numberRemoved.deletedCount === 0) {
+      response.status(409).json({ status: "No bins deleted" } ).send()
+    } else {
+      response.json({ status: "success" } ).send()
+    }
+  })
+})
 
 module.exports = router;

--- a/routes/api/bins.js
+++ b/routes/api/bins.js
@@ -46,7 +46,7 @@ router.post("/", auth.required, (request, response) => {
   });
 });
 
-router.delete("/", (request, response) => {
+router.delete("/", auth.required, (request, response) => {
   binId = request.body.bin.id
 
   Bin.deleteMany({

--- a/routes/api/bins.js
+++ b/routes/api/bins.js
@@ -27,7 +27,7 @@ router.post("/", (request, response) => {
       console.log(binType);
       Bin.create(
         {
-          properties: binType._id,
+          properties: {binType: binType._id},
           geometry: {
             coordinates: [
               Number(binRequest.bin.lng),

--- a/tests/bins.test.js
+++ b/tests/bins.test.js
@@ -54,3 +54,37 @@ describe("POST /", () => {
       .expect(422);
   })
 });
+
+describe('DELETE /', function() {
+  test("200 response when bin deleted", () => {
+    return api.delete("/api/bins")
+      .send({
+        bin: {
+          lng: -0.09943485260009766,
+          lat: 51.524992780414806,
+        }
+      })
+      .expect(200)
+  })
+
+  test("409 response when bin doesn't exist", () => {
+    return api.delete("/api/bins")
+      .send({
+        bin: {
+          lng: -0.1234,
+          lat: 51.5678,
+        }
+      })
+      .expect(409)
+  })
+
+  test("409 response when invalid query", () => {
+    return api.delete("/api/bins")
+      .send({
+        bin: {
+          hello: 'goodbye'
+        }
+      })
+      .expect(409)
+  })
+})

--- a/tests/bins.test.js
+++ b/tests/bins.test.js
@@ -83,7 +83,6 @@ describe('DELETE /', function() {
   beforeEach((done) => {
    Bin.findOne({}, (err, result) => {
       addedId = result._id
-      console.log(addedId)
       done()
     })
   });
@@ -91,6 +90,7 @@ describe('DELETE /', function() {
   test("200 response when bin deleted", () => {
 
     return api.delete("/api/bins")
+      .set("Authorization", `Token ${token}`)
       .send({
         bin: {
           id: addedId
@@ -101,6 +101,7 @@ describe('DELETE /', function() {
 
   test("400 response when bin doesn't exist", () => {
     return api.delete("/api/bins")
+      .set("Authorization", `Token ${token}`)
       .send({
         bin: {
           id: 'nope'
@@ -111,11 +112,22 @@ describe('DELETE /', function() {
 
   test("409 response when invalid query", () => {
     return api.delete("/api/bins")
+      .set("Authorization", `Token ${token}`)
       .send({
         bin: {
           hello: 'goodbye'
         }
       })
       .expect(409)
+  })
+
+  test("401 response when unauthorised", () => {
+    return api.delete("/api/bins")
+      .send({
+        bin: {
+          id: addedId
+        }
+      })
+      .expect(401)
   })
 })

--- a/tests/bins.test.js
+++ b/tests/bins.test.js
@@ -2,6 +2,7 @@ const request = require("supertest");
 const app = require("../app");
 const GJV = require('geojson-validation');
 const api = request(app);
+const Bin = require('../models/bin')
 
 require('./inMemoryDatabaseTestHelper');
 
@@ -56,26 +57,36 @@ describe("POST /", () => {
 });
 
 describe('DELETE /', function() {
+
+  let addedId
+
+  beforeEach((done) => {
+   Bin.findOne({}, (err, result) => {
+      addedId = result._id
+      console.log(addedId)
+      done()
+    })
+  });
+
   test("200 response when bin deleted", () => {
+
     return api.delete("/api/bins")
       .send({
         bin: {
-          lng: -0.09943485260009766,
-          lat: 51.524992780414806,
+          id: addedId
         }
       })
       .expect(200)
   })
 
-  test("409 response when bin doesn't exist", () => {
+  test("400 response when bin doesn't exist", () => {
     return api.delete("/api/bins")
       .send({
         bin: {
-          lng: -0.1234,
-          lat: 51.5678,
+          id: 'nope'
         }
       })
-      .expect(409)
+      .expect(400)
   })
 
   test("409 response when invalid query", () => {

--- a/tests/testData.js
+++ b/tests/testData.js
@@ -34,7 +34,7 @@ exports.binTypes = [plastic, glass, mixed, paper];
 exports.bins = [
   {
     type: 'Feature',
-    properties: plastic._id,
+    properties: {binType: plastic._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -45,7 +45,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -56,7 +56,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: glass._id,
+    properties: {binType: glass._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -67,7 +67,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: paper._id,
+    properties: {binType: paper._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -78,7 +78,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: paper._id,
+    properties: {binType: paper._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -89,7 +89,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: plastic._id,
+    properties: {binType: plastic._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -100,7 +100,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: plastic._id,
+    properties: {binType: plastic._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -111,7 +111,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: plastic._id,
+    properties: {binType: plastic._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -122,7 +122,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: glass._id,
+    properties: {binType: glass._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -133,7 +133,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -144,7 +144,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -155,7 +155,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -166,7 +166,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -177,7 +177,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: glass._id,
+    properties: {binType: glass._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -188,7 +188,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -199,7 +199,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: glass._id,
+    properties: {binType: glass._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -210,7 +210,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -221,7 +221,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -232,7 +232,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: mixed._id,
+    properties: {binType: mixed._id},
     geometry: {
       type: 'Point',
       coordinates: [
@@ -243,7 +243,7 @@ exports.bins = [
   },
   {
     type: 'Feature',
-    properties: plastic._id,
+    properties: {binType: plastic._id},
     geometry: {
       type: 'Point',
       coordinates: [


### PR DESCRIPTION
User can remove a bin via a button the info box

- Add a delete endpoint working based on ID
- Add a delete button to the endpoint
- Change to bin model: bin type properties are now inside binType in properties
- Bin's _id is duplicated in binType.properties.binId 
- Create endpoint modified to create with the new schema
- Reinstate the address in info box which was removed from master 😛 
- Post-merge, database data will need to be re-created with the new model
- User must be authenticated to delete a bin
- User will be redirected to login page if not logged in
